### PR TITLE
add unit tests for service layer covering isbn dedup, recipient updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,22 @@
 - then,  `gcloud app deploy --project bellbooks-backend src/main/appengine/app.yaml`
 
 
+## Running Tests
+
+Requires Java 17. If your system default is a different version, point Gradle at Java 17:
+
+```bash
+JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 ./gradlew test
+```
+
+To run only the service unit tests:
+
+```bash
+JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 ./gradlew test --tests "com.cocosmaj.BellBooks.service.*"
+```
+
+> **Note:** The `BellBooksApplicationTests.contextLoads()` test requires GCP credentials and will fail locally. The service unit tests run independently without any database or cloud connection.
+
 #### Controller conventions
 
 /add<entity>

--- a/build.gradle
+++ b/build.gradle
@@ -42,4 +42,12 @@ dependencyManagement {
 
 tasks.named('test') {
 	useJUnitPlatform()
+	testLogging {
+		events "passed", "skipped", "failed"
+		afterSuite { desc, result ->
+			if (!desc.parent) {
+				println "\n${result.testCount} tests: ${result.successfulTestCount} passed, ${result.failedTestCount} failed, ${result.skippedTestCount} skipped"
+			}
+		}
+	}
 }

--- a/src/test/java/com/cocosmaj/BellBooks/service/recipient/RecipientServiceTest.java
+++ b/src/test/java/com/cocosmaj/BellBooks/service/recipient/RecipientServiceTest.java
@@ -1,0 +1,239 @@
+package com.cocosmaj.BellBooks.service.recipient;
+
+import com.cocosmaj.BellBooks.exception.RecipientNotFoundException;
+import com.cocosmaj.BellBooks.model.recipient.Recipient;
+import com.cocosmaj.BellBooks.repository.recipient.RecipientRepository;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RecipientServiceTest {
+
+    @Mock
+    private RecipientRepository recipientRepository;
+
+    @InjectMocks
+    private RecipientService service;
+
+    @Nested
+    class UpdateRecipient {
+
+        @Test
+        void throwsException_whenRecipientNotFound() {
+            Recipient incoming = new Recipient();
+            incoming.setId(99L);
+
+            when(recipientRepository.findById(99L)).thenReturn(Optional.empty());
+
+            assertThrows(RecipientNotFoundException.class, () -> service.updateRecipient(incoming));
+            verify(recipientRepository, never()).save(any());
+        }
+
+        @Test
+        void updatesAssignedId_whenChanged() throws RecipientNotFoundException {
+            Recipient existing = new Recipient();
+            existing.setId(1L);
+            existing.setAssignedId("OLD_ID");
+            existing.setFirstName("John");
+            existing.setLastName("Doe");
+
+            Recipient incoming = new Recipient();
+            incoming.setId(1L);
+            incoming.setAssignedId("NEW_ID");
+            incoming.setFirstName("John");
+            incoming.setLastName("Doe");
+
+            when(recipientRepository.findById(1L)).thenReturn(Optional.of(existing));
+            when(recipientRepository.save(existing)).thenReturn(existing);
+
+            Recipient result = service.updateRecipient(incoming);
+
+            assertEquals("NEW_ID", result.getAssignedId());
+            verify(recipientRepository).save(existing);
+        }
+
+        @Test
+        void updatesFirstName_whenChanged() throws RecipientNotFoundException {
+            Recipient existing = new Recipient();
+            existing.setId(1L);
+            existing.setAssignedId("ID001");
+            existing.setFirstName("John");
+            existing.setLastName("Doe");
+
+            Recipient incoming = new Recipient();
+            incoming.setId(1L);
+            incoming.setAssignedId("ID001");
+            incoming.setFirstName("Jonathan");
+            incoming.setLastName("Doe");
+
+            when(recipientRepository.findById(1L)).thenReturn(Optional.of(existing));
+            when(recipientRepository.save(existing)).thenReturn(existing);
+
+            Recipient result = service.updateRecipient(incoming);
+
+            assertEquals("Jonathan", result.getFirstName());
+        }
+
+        @Test
+        void updatesLastName_whenChanged() throws RecipientNotFoundException {
+            Recipient existing = new Recipient();
+            existing.setId(1L);
+            existing.setAssignedId("ID001");
+            existing.setFirstName("John");
+            existing.setLastName("Doe");
+
+            Recipient incoming = new Recipient();
+            incoming.setId(1L);
+            incoming.setAssignedId("ID001");
+            incoming.setFirstName("John");
+            incoming.setLastName("Smith");
+
+            when(recipientRepository.findById(1L)).thenReturn(Optional.of(existing));
+            when(recipientRepository.save(existing)).thenReturn(existing);
+
+            Recipient result = service.updateRecipient(incoming);
+
+            assertEquals("Smith", result.getLastName());
+        }
+
+        @Test
+        void doesNotModifyFields_whenNothingChanged() throws RecipientNotFoundException {
+            Recipient existing = new Recipient();
+            existing.setId(1L);
+            existing.setAssignedId("ID001");
+            existing.setFirstName("John");
+            existing.setLastName("Doe");
+
+            Recipient incoming = new Recipient();
+            incoming.setId(1L);
+            incoming.setAssignedId("ID001");
+            incoming.setFirstName("John");
+            incoming.setLastName("Doe");
+
+            when(recipientRepository.findById(1L)).thenReturn(Optional.of(existing));
+            when(recipientRepository.save(existing)).thenReturn(existing);
+
+            Recipient result = service.updateRecipient(incoming);
+
+            assertEquals("ID001", result.getAssignedId());
+            assertEquals("John", result.getFirstName());
+            assertEquals("Doe", result.getLastName());
+        }
+    }
+
+    @Nested
+    class GetRecipientById {
+
+        @Test
+        void returnsRecipient_whenFound() throws RecipientNotFoundException {
+            Recipient recipient = new Recipient();
+            recipient.setId(1L);
+
+            when(recipientRepository.findById(1L)).thenReturn(Optional.of(recipient));
+
+            Recipient result = service.getRecipientById(1L);
+
+            assertSame(recipient, result);
+        }
+
+        @Test
+        void throwsException_whenNotFound() {
+            when(recipientRepository.findById(99L)).thenReturn(Optional.empty());
+
+            assertThrows(RecipientNotFoundException.class, () -> service.getRecipientById(99L));
+        }
+    }
+
+    @Nested
+    class GetRecipientByAssignedId {
+
+        @Test
+        void returnsRecipient_whenFound() throws RecipientNotFoundException {
+            Recipient recipient = new Recipient();
+            recipient.setId(1L);
+            recipient.setAssignedId("ABC1234");
+
+            when(recipientRepository.findByAssignedId("ABC1234")).thenReturn(Optional.of(recipient));
+
+            Recipient result = service.getRecipientByAssignedId("ABC1234");
+
+            assertSame(recipient, result);
+        }
+
+        @Test
+        void throwsException_whenNotFound() {
+            when(recipientRepository.findByAssignedId("UNKNOWN")).thenReturn(Optional.empty());
+
+            assertThrows(RecipientNotFoundException.class,
+                () -> service.getRecipientByAssignedId("UNKNOWN"));
+        }
+    }
+
+    @Nested
+    class DeleteRecipient {
+
+        @Test
+        void deletesRecipient_whenFound() throws RecipientNotFoundException {
+            Recipient recipient = new Recipient();
+            recipient.setId(1L);
+
+            when(recipientRepository.findById(1L)).thenReturn(Optional.of(recipient));
+
+            service.deleteRecipient(1L);
+
+            verify(recipientRepository).deleteById(1L);
+        }
+
+        @Test
+        void throwsException_whenNotFound() {
+            when(recipientRepository.findById(99L)).thenReturn(Optional.empty());
+
+            assertThrows(RecipientNotFoundException.class, () -> service.deleteRecipient(99L));
+            verify(recipientRepository, never()).deleteById(any());
+        }
+    }
+
+    @Nested
+    class GetRecipientLocation {
+
+        @Test
+        void returnsError_whenIdLengthIsNot7() throws Exception {
+            assertEquals("Id.length != 7", service.getRecipientLocation("123"));
+        }
+
+        @Test
+        void returnsError_whenIdIsTooLong() throws Exception {
+            assertEquals("Id.length != 7", service.getRecipientLocation("12345678"));
+        }
+
+        @Test
+        void returnsError_whenIdIsEmpty() throws Exception {
+            assertEquals("Id.length != 7", service.getRecipientLocation(""));
+        }
+    }
+
+    @Nested
+    class GetRecipients {
+
+        @Test
+        void delegatesToRepository() {
+            List<Recipient> expected = List.of(new Recipient());
+            when(recipientRepository.findAllByFirstNameContainingAndLastNameContaining("John", "Doe"))
+                .thenReturn(expected);
+
+            List<Recipient> result = service.getRecipients("John", "Doe");
+
+            assertSame(expected, result);
+        }
+    }
+}

--- a/src/test/java/com/cocosmaj/BellBooks/service/recipient/SpecialRequestServiceTest.java
+++ b/src/test/java/com/cocosmaj/BellBooks/service/recipient/SpecialRequestServiceTest.java
@@ -1,0 +1,77 @@
+package com.cocosmaj.BellBooks.service.recipient;
+
+import com.cocosmaj.BellBooks.exception.RecipientNotFoundException;
+import com.cocosmaj.BellBooks.model.recipient.Recipient;
+import com.cocosmaj.BellBooks.model.recipient.SpecialRequest;
+import com.cocosmaj.BellBooks.repository.recipient.RecipientRepository;
+import com.cocosmaj.BellBooks.repository.recipient.SpecialRequestRepository;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SpecialRequestServiceTest {
+
+    @Mock
+    private SpecialRequestRepository specialRequestRepository;
+
+    @Mock
+    private RecipientRepository recipientRepository;
+
+    @InjectMocks
+    private SpecialRequestService service;
+
+    @Nested
+    class AddSpecialRequest {
+
+        @Test
+        void savesRequest_andAddsToRecipientList() throws RecipientNotFoundException {
+            Recipient recipient = new Recipient();
+            recipient.setId(1L);
+            recipient.setSpecialRequests(new ArrayList<>());
+
+            SpecialRequest request = new SpecialRequest();
+            request.setRequest("Need vocational books");
+            request.setRecipient(recipient);
+
+            SpecialRequest savedRequest = new SpecialRequest();
+            savedRequest.setId(10L);
+            savedRequest.setRequest("Need vocational books");
+            savedRequest.setRecipient(recipient);
+
+            when(recipientRepository.findById(1L)).thenReturn(Optional.of(recipient));
+            when(specialRequestRepository.save(request)).thenReturn(savedRequest);
+            when(recipientRepository.save(recipient)).thenReturn(recipient);
+
+            SpecialRequest result = service.addSpecialRequest(request);
+
+            assertSame(savedRequest, result);
+            assertTrue(recipient.getSpecialRequests().contains(savedRequest));
+            verify(specialRequestRepository).save(request);
+            verify(recipientRepository).save(recipient);
+        }
+
+        @Test
+        void throwsException_whenRecipientNotFound() {
+            Recipient recipient = new Recipient();
+            recipient.setId(99L);
+
+            SpecialRequest request = new SpecialRequest();
+            request.setRecipient(recipient);
+
+            when(recipientRepository.findById(99L)).thenReturn(Optional.empty());
+
+            assertThrows(RecipientNotFoundException.class, () -> service.addSpecialRequest(request));
+            verify(specialRequestRepository, never()).save(any());
+        }
+    }
+}

--- a/src/test/java/com/cocosmaj/BellBooks/service/shipment/PackageContentServiceTest.java
+++ b/src/test/java/com/cocosmaj/BellBooks/service/shipment/PackageContentServiceTest.java
@@ -1,0 +1,304 @@
+package com.cocosmaj.BellBooks.service.shipment;
+
+import com.cocosmaj.BellBooks.exception.PackageContentNotFoundException;
+import com.cocosmaj.BellBooks.model.shipment.Book;
+import com.cocosmaj.BellBooks.model.shipment.PackageContent;
+import com.cocosmaj.BellBooks.model.shipment.Zine;
+import com.cocosmaj.BellBooks.repository.shipment.BookRepository;
+import com.cocosmaj.BellBooks.repository.shipment.PackageContentRepository;
+import com.cocosmaj.BellBooks.repository.shipment.ZineRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PackageContentServiceTest {
+
+    @Mock
+    private PackageContentRepository<PackageContent> packageContentRepository;
+
+    @Mock
+    private ZineRepository zineRepository;
+
+    @Mock
+    private BookRepository bookRepository;
+
+    private PackageContentService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new PackageContentService(packageContentRepository, zineRepository, bookRepository);
+    }
+
+    @Nested
+    class AddContent {
+
+        @Test
+        void returnsExistingBook_whenIsbn13AlreadyExists() {
+            Book existing = new Book();
+            existing.setId(1L);
+            existing.setTitle("Existing Book");
+            existing.setISBN13("9781234567890");
+
+            Book incoming = new Book();
+            incoming.setTitle("Existing Book");
+            incoming.setISBN13("9781234567890");
+
+            when(bookRepository.findByISBN13("9781234567890")).thenReturn(Optional.of(existing));
+
+            PackageContent result = service.addContent(incoming);
+
+            assertSame(existing, result);
+            verify(packageContentRepository, never()).save(any());
+        }
+
+        @Test
+        void returnsExistingBook_whenIsbn10AlreadyExists() {
+            Book existing = new Book();
+            existing.setId(2L);
+            existing.setTitle("Existing Book");
+            existing.setISBN10("1234567890");
+
+            Book incoming = new Book();
+            incoming.setTitle("Existing Book");
+            incoming.setISBN10("1234567890");
+
+            when(bookRepository.findByISBN10("1234567890")).thenReturn(Optional.of(existing));
+
+            PackageContent result = service.addContent(incoming);
+
+            assertSame(existing, result);
+            verify(packageContentRepository, never()).save(any());
+        }
+
+        @Test
+        void checksIsbn13BeforeIsbn10() {
+            Book existing = new Book();
+            existing.setId(1L);
+            existing.setISBN13("9781234567890");
+            existing.setISBN10("1234567890");
+
+            Book incoming = new Book();
+            incoming.setISBN13("9781234567890");
+            incoming.setISBN10("1234567890");
+            incoming.setTitle("Some Book");
+
+            when(bookRepository.findByISBN13("9781234567890")).thenReturn(Optional.of(existing));
+
+            service.addContent(incoming);
+
+            verify(bookRepository).findByISBN13("9781234567890");
+            verify(bookRepository, never()).findByISBN10(any());
+        }
+
+        @Test
+        void savesNewBook_whenNoIsbnMatch() {
+            Book incoming = new Book();
+            incoming.setTitle("New Book");
+            incoming.setISBN13("9789999999999");
+            incoming.setISBN10("9999999999");
+
+            when(bookRepository.findByISBN13("9789999999999")).thenReturn(Optional.empty());
+            when(bookRepository.findByISBN10("9999999999")).thenReturn(Optional.empty());
+            when(packageContentRepository.save(incoming)).thenReturn(incoming);
+
+            PackageContent result = service.addContent(incoming);
+
+            assertSame(incoming, result);
+            verify(packageContentRepository).save(incoming);
+        }
+
+        @Test
+        void savesBookDirectly_whenNoIsbnsProvided() {
+            Book incoming = new Book();
+            incoming.setTitle("Book Without ISBNs");
+
+            when(packageContentRepository.save(incoming)).thenReturn(incoming);
+
+            PackageContent result = service.addContent(incoming);
+
+            assertSame(incoming, result);
+            verify(bookRepository, never()).findByISBN13(any());
+            verify(bookRepository, never()).findByISBN10(any());
+            verify(packageContentRepository).save(incoming);
+        }
+
+        @Test
+        void savesDuplicateBook_whenBothLackIsbns() {
+            Book first = new Book();
+            first.setTitle("Same Title");
+
+            Book second = new Book();
+            second.setTitle("Same Title");
+
+            when(packageContentRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+            service.addContent(first);
+            service.addContent(second);
+
+            verify(packageContentRepository, times(2)).save(any());
+            verify(packageContentRepository).save(first);
+            verify(packageContentRepository).save(second);
+        }
+
+        @Test
+        void alwaysSavesZine_withoutIsbnDeduplication() {
+            Zine zine = new Zine();
+            zine.setTitle("Test Zine");
+            zine.setCode("Z001");
+
+            when(packageContentRepository.save(zine)).thenReturn(zine);
+
+            PackageContent result = service.addContent(zine);
+
+            assertSame(zine, result);
+            verify(bookRepository, never()).findByISBN13(any());
+            verify(bookRepository, never()).findByISBN10(any());
+            verify(packageContentRepository).save(zine);
+        }
+
+        @Test
+        void savesDuplicateZine_whenTitleAndCodeAlreadyExist() {
+            Zine first = new Zine();
+            first.setTitle("Prison Abolition Weekly");
+            first.setCode("PAW-01");
+
+            Zine second = new Zine();
+            second.setTitle("Prison Abolition Weekly");
+            second.setCode("PAW-01");
+
+            when(packageContentRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+            service.addContent(first);
+            service.addContent(second);
+
+            verify(packageContentRepository).save(first);
+            verify(packageContentRepository).save(second);
+        }
+    }
+
+    @Nested
+    class GetContent {
+
+        @Test
+        void returnsContent_whenFound() throws PackageContentNotFoundException {
+            Book book = new Book();
+            book.setId(1L);
+            book.setTitle("Found Book");
+
+            when(packageContentRepository.findById(1L)).thenReturn(Optional.of(book));
+
+            PackageContent result = service.getContent(1L);
+
+            assertSame(book, result);
+        }
+
+        @Test
+        void throwsException_whenNotFound() {
+            when(packageContentRepository.findById(99L)).thenReturn(Optional.empty());
+
+            assertThrows(PackageContentNotFoundException.class, () -> service.getContent(99L));
+        }
+    }
+
+    @Nested
+    class UpdateContent {
+
+        @Test
+        void savesContent_whenItExists() throws PackageContentNotFoundException {
+            Book book = new Book();
+            book.setId(1L);
+            book.setTitle("Updated Title");
+
+            when(packageContentRepository.findById(1L)).thenReturn(Optional.of(book));
+            when(packageContentRepository.save(book)).thenReturn(book);
+
+            PackageContent result = service.updateContent(book);
+
+            assertSame(book, result);
+            verify(packageContentRepository).save(book);
+        }
+
+        @Test
+        void throwsException_whenContentDoesNotExist() {
+            Book book = new Book();
+            book.setId(99L);
+
+            when(packageContentRepository.findById(99L)).thenReturn(Optional.empty());
+
+            assertThrows(PackageContentNotFoundException.class, () -> service.updateContent(book));
+        }
+    }
+
+    @Nested
+    class DeleteContent {
+
+        @Test
+        void deletesContent_whenItExists() throws PackageContentNotFoundException {
+            Book book = new Book();
+            book.setId(1L);
+
+            when(packageContentRepository.findById(1L)).thenReturn(Optional.of(book));
+
+            service.deleteContent(1L);
+
+            verify(packageContentRepository).deleteById(1L);
+        }
+
+        @Test
+        void throwsException_whenContentDoesNotExist() {
+            when(packageContentRepository.findById(99L)).thenReturn(Optional.empty());
+
+            assertThrows(PackageContentNotFoundException.class, () -> service.deleteContent(99L));
+        }
+    }
+
+    @Nested
+    class GetContentByTitleAndAuthor {
+
+        @Test
+        void searchesByTitleOnly_whenAuthorIsNull() {
+            List<PackageContent> expected = List.of();
+            when(bookRepository.findAllByTitleContaining("Java")).thenReturn(expected);
+
+            List<PackageContent> result = service.getContentByTitleAndAuthor("Java", null);
+
+            assertSame(expected, result);
+            verify(bookRepository).findAllByTitleContaining("Java");
+            verify(bookRepository, never()).findAllByTitleContainingAndAuthorsContaining(any(), any());
+        }
+
+        @Test
+        void searchesByTitleOnly_whenAuthorIsEmpty() {
+            List<PackageContent> expected = List.of();
+            when(bookRepository.findAllByTitleContaining("Java")).thenReturn(expected);
+
+            List<PackageContent> result = service.getContentByTitleAndAuthor("Java", "");
+
+            assertSame(expected, result);
+            verify(bookRepository).findAllByTitleContaining("Java");
+            verify(bookRepository, never()).findAllByTitleContainingAndAuthorsContaining(any(), any());
+        }
+
+        @Test
+        void searchesByTitleAndAuthor_whenAuthorIsProvided() {
+            List<PackageContent> expected = List.of();
+            when(bookRepository.findAllByTitleContainingAndAuthorsContaining("Java", "Bloch"))
+                .thenReturn(expected);
+
+            List<PackageContent> result = service.getContentByTitleAndAuthor("Java", "Bloch");
+
+            assertSame(expected, result);
+            verify(bookRepository).findAllByTitleContainingAndAuthorsContaining("Java", "Bloch");
+        }
+    }
+}

--- a/src/test/java/com/cocosmaj/BellBooks/service/shipment/ShipmentServiceTest.java
+++ b/src/test/java/com/cocosmaj/BellBooks/service/shipment/ShipmentServiceTest.java
@@ -1,0 +1,124 @@
+package com.cocosmaj.BellBooks.service.shipment;
+
+import com.cocosmaj.BellBooks.exception.ShipmentNotFoundException;
+import com.cocosmaj.BellBooks.model.shipment.Shipment;
+import com.cocosmaj.BellBooks.repository.shipment.ShipmentRepository;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ShipmentServiceTest {
+
+    @Mock
+    private ShipmentRepository shipmentRepository;
+
+    @InjectMocks
+    private ShipmentService service;
+
+    @Nested
+    class GetShipment {
+
+        @Test
+        void returnsShipment_whenFound() throws ShipmentNotFoundException {
+            Shipment shipment = new Shipment();
+            shipment.setId(1L);
+
+            when(shipmentRepository.findById(1L)).thenReturn(Optional.of(shipment));
+
+            Shipment result = service.getShipment(1L);
+
+            assertSame(shipment, result);
+        }
+
+        @Test
+        void throwsException_whenNotFound() {
+            when(shipmentRepository.findById(99L)).thenReturn(Optional.empty());
+
+            assertThrows(ShipmentNotFoundException.class, () -> service.getShipment(99L));
+        }
+    }
+
+    @Nested
+    class UpdateShipment {
+
+        @Test
+        void savesShipment_whenItExists() throws ShipmentNotFoundException {
+            Shipment shipment = new Shipment();
+            shipment.setId(1L);
+            shipment.setDate(LocalDate.of(2024, 1, 15));
+
+            when(shipmentRepository.findById(1L)).thenReturn(Optional.of(shipment));
+            when(shipmentRepository.save(shipment)).thenReturn(shipment);
+
+            Shipment result = service.updateShipment(shipment);
+
+            assertSame(shipment, result);
+            verify(shipmentRepository).save(shipment);
+        }
+
+        @Test
+        void throwsException_whenShipmentDoesNotExist() {
+            Shipment shipment = new Shipment();
+            shipment.setId(99L);
+
+            when(shipmentRepository.findById(99L)).thenReturn(Optional.empty());
+
+            assertThrows(ShipmentNotFoundException.class, () -> service.updateShipment(shipment));
+            verify(shipmentRepository, never()).save(any());
+        }
+    }
+
+    @Nested
+    class DeleteShipment {
+
+        @Test
+        void deletesWithoutExistenceCheck() {
+            service.deleteShipment(1L);
+
+            verify(shipmentRepository).deleteById(1L);
+        }
+    }
+
+    @Nested
+    class GetShipmentsByDate {
+
+        @Test
+        void delegatesToRepository() {
+            LocalDate date = LocalDate.of(2024, 6, 15);
+            List<Shipment> expected = List.of(new Shipment());
+
+            when(shipmentRepository.findAllByDate(date)).thenReturn(expected);
+
+            List<Shipment> result = service.getShipmentsByDate(date);
+
+            assertSame(expected, result);
+        }
+    }
+
+    @Nested
+    class GetShipmentCountBetweenDates {
+
+        @Test
+        void delegatesToRepository() {
+            LocalDate start = LocalDate.of(2024, 1, 1);
+            LocalDate end = LocalDate.of(2024, 12, 31);
+
+            when(shipmentRepository.countByDateBetween(start, end)).thenReturn(42L);
+
+            Long result = service.getShipmentCountBetweenDates(start, end);
+
+            assertEquals(42L, result);
+        }
+    }
+}


### PR DESCRIPTION
add unit tests for service layer covering isbn dedup, recipient updates

also:
- add test count summary to gradle output
- document how to run tests in readme